### PR TITLE
fix: allow parse huge xml data

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libfastrpc (8.0.11) stable; urgency=medium
+
+  * fix: allow parse huge xml data
+
+ -- Martin Junk <martin.junk@firma.seznam.cz>  Fri, 10 Aug 2018 16:32:14 +0200
+
 libfastrpc (8.0.10) stable; urgency=medium
 
   * fix: http client when using unix socket

--- a/src/frpcxmlunmarshaller.cc
+++ b/src/frpcxmlunmarshaller.cc
@@ -245,6 +245,7 @@ XmlUnMarshaller_t::XmlUnMarshaller_t(DataBuilder_t & dataBuilder)
     callbacks.characters = (charactersSAXFunc)&charactersXML;
 
     parser =  xmlCreatePushParserCtxt(&callbacks,this,0,0,0);
+    parser->options = parser->options | XML_PARSE_HUGE;
 
 //    xmlCtxtResetPush(parser,0,0,0,"UTF-8");
 


### PR DESCRIPTION
Fixed problem with huge xml rpc response.

error: xml:parse() fails with "Huge input lookup" 

https://bugs.launchpad.net/zorba/+bug/1073754